### PR TITLE
Fix for keyboard input data

### DIFF
--- a/device.py
+++ b/device.py
@@ -90,7 +90,9 @@ class device:
 						return 0x0000
 					self.buffer.append(ord("\n"))
 			if len(self.buffer)>1:
-				return self.buffer.pop(0)*0x0100+self.buffer.pop(0)
+				value = self.buffer.pop(0)*0x0100+self.buffer.pop(0)
+				self.buffer.clear()
+				return value
 			else:
 				if self.quiet:
 					print("Not enough data on buffer, returning 0x0000")


### PR DESCRIPTION
This fixes a well know issue regarding keyboard input data in MVN.

Basically, the issue arises when trying to use the D opcode instruction more than once in a program, where the first instruction executes properly, but the rest dont, as show in the excerpt below

```
> p lab05-vSasakiv\submission\io.mvn
Program lab05-vSasakiv\submission\io.mvn loaded

> b
Debugger mode activated

> r
Inform IC address [0000]:
Starting simulation
dbg commands are
 COMMAND  PARAMETERS           OPERATION
---------------------------------------------------------------------------
    c                          Continue execution
    s                          Make one step forward on execution
    b     [addr]               Insert a breakpoint
    x                          Pause execution
    h                          Help
    r     [reg] [val]          Place value on register
    a     [addr] [val]         Place value in memory
    e                          Show register values
    m     [ini] [fim]          List memory content
 MAR  MDR  IC   IR   OP   OI   AC
---- ---- ---- ---- ---- ---- ----
(dgb) s
07
0000 d000 0002 d000 000d 0000 3037
(dgb) s
0200 3030 0004 5200 0005 0200 0007
(dgb) s
0100 0007 0006 9100 0009 0100 0007
(dgb) s
54
0006 d000 0008 d000 000d 0000 0a35
(dgb) s
0200 3030 000a 5200 0005 0200 da05
(dgb)
```
We expect to get 3534 after the 54 is typed, but end up with 0a35 (0a is the end of line character \n)

After investigating the code, I came to notice that in the `get_data()` function in the device.py file, where the inputs are read, a buffer is used to store the characters, however, the way that we get the return values, is by popping the first element twice, and as a consequence, the buffer is never fully cleared, meaning that, if we have more than 3 bytes worth of characters inside the buffer, the next time we read data, the first character will be the one remaining from the last interaction.
That's ok, but why do we have more than 3 bytes worth of characters in the example above, if we only type in 2 numbers? Well, the answer lies in the code below:

```
		if case(0):
			if len(self.buffer)<2:
				if limit==None:
					read=input()
					for nibble in read:
						self.buffer.append(ord(nibble))
					self.buffer.append(ord("\n"))
				else:
					read, o, e = select.select( [sys.stdin], [], [], limit/1000)
					if read:
						for nibble in sys.stdin.readline().strip():
							self.buffer.append(ord(nibble))
					else:
						if self.quiet:
							print("Not enough data on buffer, returning 0x0000")
						return 0x0000
					self.buffer.append(ord("\n"))
			if len(self.buffer)>1:
				return self.buffer.pop(0)*0x0100+self.buffer.pop(0)
```

Everything looks good there, except that, after reading and stripping the input string, for some reason, a '\n' is appended to the end of the buffer, and that is our 3rd character, that gets dragged onto the next read operation, and is the source of the a0 byte.

My solution is simple, but not very cautious, as I have not studied the code further to know if it conflicts with anything else, but it works in my tests: simply clear the buffer every time we finish reading, so that it does not interfere with the next reading.